### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
         with:
           url: ${{ secrets.SHOUTRRR_URL }}
           title: Deployed ${{ github.sha }}
-          message: See changes at ${{ github.event.commpare }}.
+          message: See changes at ${{ github.event.compare }}.
 ```
 
 The `url` is the Shoutrrr service URL as described in the [service


### PR DESCRIPTION
The event property is called compare - not commpare.

For someone just copy/pasting from the example a small typo here might cause confusion.

Please describe the bug fix or feature you would like to introduce.
