### PR TITLE
Shorten release name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,5 +61,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.version.outputs.new_tag }}
-          name: Release ${{ steps.version.outputs.new_tag }} (${{ steps.shoutrrr.outputs.version }})
+          name: ${{ steps.version.outputs.new_tag }} (${{ steps.shoutrrr.outputs.version }})
           bodyFile: ${{ runner.temp }}/ChangeLog.md


### PR DESCRIPTION
Now that we have added the shoutrrr version to the release name we have
a rather long release name. We'll drop the redundant "Release" from the
release name to shorten it.

<!--

Thank you for contributing to the shoutrrr-action project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code you are contributing
- Updates to the documentation

Thank you again! ✨

-->
