### PR TITLE
Potential fix for code scanning alert no. 67: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/containrrr/shoutrrr-action/security/code-scanning/67](https://github.com/containrrr/shoutrrr-action/security/code-scanning/67)

To fix the problem, add a `permissions` key to the workflow or (best-practice) to the `jobs.release` job. This restricts the default permissions granted via `GITHUB_TOKEN`. For this workflow, since it checks out code (`actions/checkout@v5`), pushes tags, and creates releases (using `ncipollo/release-action@v1`), it specifically needs `contents: write`. If the workflow also interacts with issues or pull requests, further permissions may be needed, but none are evident here. Therefore, add the following to the job:

```yaml
permissions:
  contents: write
```

Add this as the first entry under `jobs.release:` (e.g., on a new line after `release:` and before `runs-on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
